### PR TITLE
Change color output of confirmation of item addition

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -91,7 +91,7 @@ func main() {
 					fmt.Println(err)
 				}
 
-				ct.ChangeColor(ct.Red, false, ct.None, false)
+				ct.ChangeColor(ct.Cyan, false, ct.None, false)
 				fmt.Printf("\"%s\" is now added to your todos.\n", c.Args()[0])
 				ct.ResetColor()
 			},


### PR DESCRIPTION
The output after adding a new todo item happens to appear in RED. This
has been used across the application to signify an error. To maintain
consistency and better user experience, color output be changed from RED
to CYAN.