### PR TITLE
Save the todo json file with indentation

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -59,7 +59,12 @@ func (c *Collection) WriteTodos() error {
 
 	defer file.Close()
 
-	err = json.NewEncoder(file).Encode(&c.Todos)
+	data, err := json.MarshalIndent(&c.Todos, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(data)
 	return err
 }
 


### PR DESCRIPTION
This commit changes the way the todo file is saved. It now saves the
file with a friendly json format.

This is to make easier to edit the file to make small adjustments which
are not possible to do using the td command yet.