### PR TITLE
Added missing line break for modify command output

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -151,7 +151,7 @@ func main() {
 				}
 
 				ct.ChangeColor(ct.Cyan, false, ct.None, false)
-				fmt.Printf("\"%s\" has now a new description: %s", c.Args()[0], c.Args()[1])
+				fmt.Printf("\"%s\" has now a new description: %s\n", c.Args()[0], c.Args()[1])
 				ct.ResetColor()
 			},
 		},


### PR DESCRIPTION
The message printed after running the modify command successfully had no
line break ("\n") at the end making the shell 'look' strange with the
message followed by the shell 'PROMPT'