### PR TITLE
Added the option to reorder according to the given ID list

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -217,9 +217,38 @@ func main() {
 			Name:      "reorder",
 			ShortName: "r",
 			Usage:     "Reset ids of todo (no arguments) or swap the position of two todos",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "exact, e",
+					Usage: "Reorder the list according to the specified IDs and append the remaining items to the end of the list",
+				},
+			},
 			Action: func(c *cli.Context) {
 				collection := Collection{}
 				collection.RetrieveTodos()
+
+				exact := c.Bool("exact")
+				if exact {
+					ids := make([]int64, len(c.Args()))
+					for i, sid := range c.Args() {
+						id, err := strconv.ParseInt(sid, 10, 32)
+						if err != nil {
+							fmt.Println(err)
+							return
+						}
+						ids[i] = id
+					}
+
+					if err := collection.ReorderByIDs(ids); err != nil {
+						fmt.Println(err)
+						return
+					}
+
+					ct.ChangeColor(ct.Cyan, false, ct.None, false)
+					fmt.Println("Your list is now reordered.")
+					ct.ResetColor()
+					return
+				}
 
 				if len(c.Args()) == 1 {
 					fmt.Println()

--- a/collection.go
+++ b/collection.go
@@ -199,3 +199,44 @@ func (c *Collection) Search(sentence string) {
 		}
 	}
 }
+
+func (c *Collection) ReorderByIDs(ids []int64) error {
+	idsMap := map[int64]int{}
+	for index, id := range ids {
+		idsMap[id] = index
+	}
+
+	ordered := make([]*Todo, len(ids))
+	rest := []*Todo{}
+
+	for _, todo := range c.Todos {
+		if index, ok := idsMap[todo.Id]; ok {
+			ordered[index] = todo
+			continue
+		}
+		rest = append(rest, todo)
+	}
+
+	newTodos := make([]*Todo, len(c.Todos))
+	index := 0
+	var idCounter int64 = 1
+	for _, todo := range ordered {
+		if todo == nil {
+			continue
+		}
+		todo.Id = idCounter
+		newTodos[index] = todo
+		index++
+		idCounter++
+	}
+	for _, todo := range rest {
+		todo.Id = idCounter
+		newTodos[index] = todo
+		index++
+		idCounter++
+	}
+
+	c.Todos = newTodos
+
+	return c.WriteTodos()
+}


### PR DESCRIPTION
When reordering the user can specify a list with the IDs in the order
they should be.

Not all IDs have to be specified, the IDs not present in the list will
be added to the end of the ordered list.